### PR TITLE
Passing on __file__ with the __main__.__dict__

### DIFF
--- a/MayaSublime.py
+++ b/MayaSublime.py
@@ -38,21 +38,22 @@ class SendToMayaCommand(sublime_plugin.TextCommand):
 
 		snips = []
 
-		# if selSize == 0:
-		# 	print "Nothing Selected, Attempting to Source/Import Current File"
-		# 	if self.view.is_dirty():
-		# 		sublime.error_message("Save Changes Before Maya Source/Import")
-		# 	else:
-		# 		file_path = self.view.file_name()
-		# 		if file_path is not None:
-		# 			file_name = os.path.basename(file_path)
-		# 			module_name = os.path.splitext(file_name)[0]
+		if selSize == 0:
+		 	print "Nothing Selected, Attempting to Source/Import Current File"
+		 	if self.view.is_dirty():
+		 		sublime.error_message("Save Changes Before Maya Source/Import")
+		 	else:
+		 		file_path = self.view.file_name()
+		 		if file_path is not None:
+		 			file_name = os.path.basename(file_path)
+		 			module_name = os.path.splitext(file_name)[0]
 					
-		# 			if lang == 'python':
-		# 				snips.append('import {0}\nreload({0})'.format(module_name))
-		# 			else:
-		# 				snips.append('rehash; source {0};'.format(module_name))
-		# 			#print "SNIPS:", snips
+		 			if lang == 'python':
+		 				snips.append('import sys\nsys.path.append( \'{0}\' )'.format( os.path.dirname(os.path.realpath(file_path)) ))
+		 				snips.append('import {0}\nreload({0})'.format(module_name))
+		 			else:
+		 				snips.append('rehash; source {0};'.format(module_name))
+		 			#print "SNIPS:", snips
 		
 		for sel in selections:
 			snips.extend(line.replace(r"'''", r"\'\'\'") for line in 


### PR DESCRIPTION
When sending a file to execfile() I also pass on '**file**' which is great. Now my scripts can import or link to other files which locations are defined relative to the script file's file path ('**file**').

I wasn't sure on how to pull the latest file from your repo and go from there, so I copy-pasted the contents of your current MayaSublime.py and edited the two parts accordingly (which kind of messed up the diff that is shown here when typing this request) and made a commit. Seems like now GitHub wants to make two commits to your code – which wasn't what I intended.. This is all I was wishing to add to your repo:

<pre>   PY_CMD_TEMPLATE = textwrap.dedent('''
        import traceback
        import __main__
        g = __main__.__dict__.copy()    # added
        g['__file__'] = '{2}'           # added
        try:
            {0}({1!r}, g, g)            # changed
        except:
            traceback.print_exc() 
    ''')</pre>


and...

<pre>mCmd = self.PY_CMD_TEMPLATE.format(execType, mCmd, file_path)  #changed</pre>


I'll close the issue I made regarding this.
