### PR TITLE
Add "no_collisions" setting to toggle namespacing Python code

### DIFF
--- a/MayaSublime.py
+++ b/MayaSublime.py
@@ -45,10 +45,12 @@ class send_to_mayaCommand(sublime_plugin.TextCommand):
 			namespace = __main__.__dict__.copy()
 			__main__.__dict__['_sublime_SendToMaya_plugin'] = namespace
 
-		namespace['__file__'] = {fp!r}
-
 		try:
-			{xtype}({cmd!r}, namespace, namespace)
+			if {ns}:
+				namespace['__file__'] = {fp!r}
+				{xtype}({cmd!r}, namespace, namespace)
+			else:
+				{xtype}({cmd!r})
 		except:
 			traceback.print_exc() 
 	''')
@@ -146,7 +148,8 @@ class send_to_mayaCommand(sublime_plugin.TextCommand):
 		if lang == 'python':
 			# We need to wrap our source string into a template
 			# so that it gets executed properly on the Maya side
-			opts = dict(xtype=execType, cmd=mCmd, fp=file_path)
+			no_collide = _settings['no_collisions']
+			opts = dict(xtype=execType, cmd=mCmd, fp=file_path, ns=no_collide)
 			mCmd = self.PY_CMD_TEMPLATE.format(**opts)
 
 		c = None
@@ -183,6 +186,7 @@ def sync_settings():
 	_settings['py_port']        = so.get('python_command_port')
 	_settings['mel_port']       = so.get('mel_command_port')
 	_settings['strip_comments'] = so.get('strip_sending_comments')
+	_settings['no_collisions']  = so.get('no_collisions')
 	
 
 

--- a/MayaSublime.py
+++ b/MayaSublime.py
@@ -45,10 +45,10 @@ class send_to_mayaCommand(sublime_plugin.TextCommand):
 			namespace = __main__.__dict__.copy()
 			__main__.__dict__['_sublime_SendToMaya_plugin'] = namespace
 
-		namespace['__file__'] = {2!r}
+		namespace['__file__'] = {fp!r}
 
 		try:
-			{0}({1!r}, namespace, namespace)
+			{xtype}({cmd!r}, namespace, namespace)
 		except:
 			traceback.print_exc() 
 	''')
@@ -146,7 +146,8 @@ class send_to_mayaCommand(sublime_plugin.TextCommand):
 		if lang == 'python':
 			# We need to wrap our source string into a template
 			# so that it gets executed properly on the Maya side
-			mCmd = self.PY_CMD_TEMPLATE.format(execType, mCmd, file_path)
+			opts = dict(xtype=execType, cmd=mCmd, fp=file_path)
+			mCmd = self.PY_CMD_TEMPLATE.format(**opts)
 
 		c = None
 

--- a/MayaSublime.sublime-settings
+++ b/MayaSublime.sublime-settings
@@ -20,5 +20,12 @@
 	//
 	// When sending whole files (nothing selected),
 	// comments are never stripped.
-	"strip_sending_comments": true
+	"strip_sending_comments": true,
+
+	// This wraps Python code in its own namespace
+	// to avoid collisions with the main Maya
+	// environment. (It is safer but if you are
+	// mixing this plugin with code from the
+	// Script Editor, set this to false.)
+	"no_collisions": true,
 }


### PR DESCRIPTION
Hey,

In my opinion while it's good to namespace code by default, it can cause confusion as it's not really mentioned to the user.

I actually had an issue where I was defining a class in Sublime and using MayaSublime to send it to Maya, then trying it out in the Script Editor... except that it wasn't in the main environment, so weirdness ensued.

My proposed change leaves the current behaviour as default but allows the user to disable the namespacing at their own peril. Let me know what you think or if you'd like me to adjust anything.
