### PR TITLE
Update for >= python 3.7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 *.sublime-project
 *.sublime-workspace
+.idea/
+*.iml

--- a/MayaSublime.py
+++ b/MayaSublime.py
@@ -282,9 +282,17 @@ PY_CMD_TEMPLATE = textwrap.dedent('''
 
 		if {ns}:
 			namespace['__file__'] = {fp!r}
-			{xtype}({cmd!r}, namespace, namespace)
 		else:
-			{xtype}({cmd!r}, __main__.__dict__, __main__.__dict__)
+			namespace = __main__.__dict__
+
+		if {xtype!r} == "exec":
+			exec({cmd!r}, namespace, namespace)
+
+		else:
+			with open({fp!r}) as _fp:
+				_code = compile(_fp.read(), {fp!r}, 'exec')
+				exec(_code, namespace, namespace)
+				
 	except:
 		traceback.print_exc() 
 	finally:

--- a/MayaSublime.py
+++ b/MayaSublime.py
@@ -1,14 +1,11 @@
 # ST2/ST3 compat
 from __future__ import print_function
 
-import os
 import re
 import sys
 import time
 import uuid
-import errno
 import socket
-import os.path
 import textwrap
 import threading 
 import traceback
@@ -92,11 +89,9 @@ class send_to_mayaCommand(sublime_plugin.TextCommand):
 			print('No Maya-Recognized Language Found')
 			return
 
-		isPython = (lang=='python')
-
 		# Apparently ST3 doesn't always sync up its latest 
 		# plugin settings?
-		if _settings['host'] is None:
+		if not _settings['host']:
 			sync_settings()
 
 		# Check the current selection size to determine 
@@ -183,7 +178,7 @@ def _send_to_maya(cmd, lang='python', wrap=True, quiet=False):
 	"""
 	Send stringified Python code to Maya, to be executed. 
 	"""
-	if _settings['host'] is None:
+	if not _settings['host']:
 		sync_settings()
 		
 	host = _settings['host']
@@ -250,14 +245,14 @@ def sync_settings():
 def _sync_settings():
 	so = settings_obj()
 
-	_settings['host']           = so.get('maya_hostname')
-	_settings['py_port']        = so.get('python_command_port')
-	_settings['mel_port']       = so.get('mel_command_port')
-	_settings['strip_comments'] = so.get('strip_sending_comments')
-	_settings['no_collisions']  = so.get('no_collisions')
-	_settings['maya_output']    = so.get('receive_maya_output')
-	_settings['undo']           = so.get('create_undo')
-
+	_settings['host']           = so.get('maya_hostname', _settings['host'])
+	_settings['py_port']        = so.get('python_command_port', _settings['py_port'])
+	_settings['mel_port']       = so.get('mel_command_port', _settings['mel_port']  )
+	_settings['strip_comments'] = so.get('strip_sending_comments', _settings['strip_comments'])
+	_settings['no_collisions']  = so.get('no_collisions', _settings['no_collisions'])
+	_settings['maya_output']    = so.get('receive_maya_output', _settings['maya_output'])
+	_settings['undo']           = so.get('create_undo', _settings['undo'] )
+	
 	MayaReader._st2_remove_reader()
 
 	if _settings['maya_output'] is not None:

--- a/messages.json
+++ b/messages.json
@@ -8,5 +8,6 @@
     "3.0.1": "messages/3.0.1.md",
     "3.0.2": "messages/3.0.2.md",
     "3.0.3": "messages/3.0.3.md",
-    "3.0.4": "messages/3.0.4.md"
+    "3.0.4": "messages/3.0.4.md",
+    "3.1.0": "messages/3.1.0.md"
 }

--- a/messages/3.1.0.md
+++ b/messages/3.1.0.md
@@ -1,0 +1,4 @@
+MayaSublime 3.1.0 change log:
+
+- [#36]: Update to support python >= 3.7 (refactor lack of `execfile`)
+- Improve settings sync and handling of default values


### PR DESCRIPTION
This PR replaces the deprecated `execfile` approach to loading a whole source file with code that is compatible with python 3.7+
Also included in this merge is an improvement to the handling of default settings.

Fixes #36 